### PR TITLE
Add ability to override encoding.DefaultAllocLimit

### DIFF
--- a/internal/test/models.go
+++ b/internal/test/models.go
@@ -1,6 +1,7 @@
 package test
 
-//go:generate encodegen -t TestMessageSimple,TestMessageEmbedded
+// encoding.DefaultAllocLimit is already 1e6 but we use it as the expression to test if overriding works
+//go:generate encodegen -t TestMessageSimple,TestMessageEmbedded:1e6
 
 import (
 	imported "go.sia.tech/encodegen/internal/test/imported"

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 	}
 
 	dst := flag.String("o", "", "output file name; default srcdir/encoding.go")
-	typs := flag.String("t", "", "comma-separated list of type names; to override default unmarshaler allocation limit, add a colon and then the expression replacing it after; required")
+	typs := flag.String("t", "", "comma-separated list of type names; to (optionally) override default unmarshaler allocation limit, add a colon and then the expression replacing it after; required")
 	flag.Parse()
 	args := flag.Args()
 

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 	}
 
 	dst := flag.String("o", "", "output file name; default srcdir/encoding.go")
-	typs := flag.String("t", "", "comma-separated list of type names; required")
+	typs := flag.String("t", "", "comma-separated list of type names; to override default unmarshaler allocation limit, add a colon and then the expression replacing it after; required")
 	flag.Parse()
 	args := flag.Args()
 


### PR DESCRIPTION
This pull request adds the ability to override the default unmarshaler allocation limit.

Now when invoking the command, you can simply add the expression to replace `encoding.DefaultAllocLimit` with after a colon, i.e.:

    encodegen -t TestMessageSimple,TestMessageEmbedded:1e6

or:

    encodegen -t "TestMessageSimple:1<<18,TestMessageEmbedded:1e6"

or just leave the default:

    encodegen -t TestMessageSimple,TestMessageEmbedded

This is useful for types like [`Block`](https://github.com/SiaFoundation/siad/blob/c846c135218cf3ba51bb1978ee8709038173e972/types/block.go#L27) that can be up to [2 MB](https://github.com/SiaFoundation/siad/blob/c846c135218cf3ba51bb1978ee8709038173e972/types/constants.go#L52), which is greater than encoding.DefaultAllocLimit (currently 1 MB).  Currently this is addressed by just manually [specifying the limit](https://github.com/SiaFoundation/siad/blob/c846c135218cf3ba51bb1978ee8709038173e972/types/encoding.go#L39) in the `UnmarshalSia` functions, but eventually we want to codegen most types so this will be necessary.