### PR TITLE
Skip type check when already implemented

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -161,6 +161,12 @@ import (%s)
 func (g *generator) checkType(typName string) error {
 	var check func(t types.Type, ctx string) error
 	check = func(t types.Type, ctx string) error {
+		// If the type already implements both the marshal and unmarshal interface
+		// we can skip checking since the generater will use them.
+		if types.Implements(t, siaMarshaler) && types.Implements(types.NewPointer(t), siaUnmarshaler) {
+			return nil
+		}
+
 		switch t := t.Underlying().(type) {
 		case *types.Basic:
 			if t.Info()&types.IsInteger != 0 || t.Kind() == types.Bool || t.Kind() == types.String {


### PR DESCRIPTION
I'm not sure this is the ideal solution. It fixes an issue I was having when generating encoding for structs that had `types.Currency` fields even though it already implements both interfaces.

```go
type Test struct {
    Field types.Currency
}
```

### Observed
```
encodegen: cannot generate methods for type Test: unexported field i at (Test).Field
```

### Expected
```go
// MarshalSia implements encoding.SiaMarshaler.
func (x Test) MarshalSia(w io.Writer) error {
	e := encoding.NewEncoder(w)
	x.Field.MarshalSia(e)
	return e.Err()
}

// UnmarshalSia implements encoding.SiaUnmarshaler.
func (x *Test) UnmarshalSia(r io.Reader) error {
	d := encoding.NewDecoder(r, encoding.DefaultAllocLimit)
	x.Field.UnmarshalSia(d)
	return d.Err()
}
```